### PR TITLE
fix indent_style in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@
 root = true
 
 [*]
-indent_style = spaces
+indent_style = space
 indent_size = 4
 end_of_line = lf
 charset = utf-8


### PR DESCRIPTION
according to documentation:

> indent_style: set to **tab** or **space** to use hard tabs or soft tabs respectively.

Don't **spaces**